### PR TITLE
Fix checking fk existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dependencies:
     version: "0.18.0"
   jennifer_sqlite3_adapter:
     github: imdrasil/jennifer_sqlite3_adapter
-    version: "~> 0.3.1"
+    version: "~> 0.3.2"
 ```
 
 > Current adapter version is tested with `0.18.0` sqlite3 driver but other versions may also work

--- a/shard.yml
+++ b/shard.yml
@@ -11,8 +11,8 @@ development_dependencies:
     version: "0.18.0"
   jennifer:
     github: imdrasil/jennifer.cr
-    version: "0.11.0"
-    # branch: "master"
+    # version: "0.11.0"
+    branch: "master"
   sam:
     github: imdrasil/sam.cr
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -11,8 +11,7 @@ development_dependencies:
     version: "0.18.0"
   jennifer:
     github: imdrasil/jennifer.cr
-    # version: "0.11.0"
-    branch: "master"
+    version: "0.11.1"
   sam:
     github: imdrasil/sam.cr
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: jennifer_sqlite3_adapter
-version: 0.3.1
+version: 0.3.2
 crystal: ">= 0.36.0"
 
 authors:

--- a/spec/sqlite3/schema_processor_spec.cr
+++ b/spec/sqlite3/schema_processor_spec.cr
@@ -103,7 +103,7 @@ describe Jennifer::SQLite3::SchemaProcessor do
         adapter.table_exists?("posts").should be_true
         adapter.table_exists?("posts_temp").should be_false
         Post.all.count.should eq(2)
-        # adapter.index_exists?("users", "name_index").should be_true
+        adapter.index_exists?("users", "name_index").should be_true
         master_class.table("posts").first!.foreign_keys.should be_empty
       end
     end

--- a/src/jennifer_sqlite3_adapter.cr
+++ b/src/jennifer_sqlite3_adapter.cr
@@ -101,12 +101,16 @@ module Jennifer
       end
 
       def foreign_key_exists?(from_table, to_table = nil, column = nil, name : String? = nil) : Bool
-        raise ArgumentError.new("SQLite3 adapter doesn't support ") if name
+        raise ArgumentError.new("SQLite3 adapter doesn't support #foreign_key_exists? with key name") if name
+
         table = MetaTable.table(from_table).first
         return false unless table && (to_table || column)
 
+        to_table = to_table.to_s if to_table
+        column = column.to_s if column
         table.foreign_keys.any? do |fk|
           result = true
+          puts fk.inspect
           result &= fk.to_table == to_table if to_table
           result &= fk.column == column if column
           result

--- a/src/jennifer_sqlite3_adapter.cr
+++ b/src/jennifer_sqlite3_adapter.cr
@@ -8,7 +8,7 @@ require "./sqlite3/meta/meta_table"
 module Jennifer
   module SQLite3
     # Library version.
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
 
     class Adapter < Adapter::Base
       alias EnumType = String

--- a/src/sqlite3/schema_processor.cr
+++ b/src/sqlite3/schema_processor.cr
@@ -11,29 +11,6 @@ module Jennifer
         adapter.exec "DROP INDEX #{name}"
       end
 
-      def drop_column(table, name)
-        ignore_foreign_keys do
-          temp_table_name = "#{table}_temp"
-          t = find_table(table)
-          columns = t.columns.reject(&.name.==(name.to_s))
-
-          # Create new table
-          create_table(temp_table_name, columns, t.foreign_keys)
-
-          # Copy data
-          copy_data(temp_table_name, table, columns.map(&.name))
-
-          # Drop old table
-          drop_table(table)
-
-          # Rename new table
-          rename_table(temp_table_name, table)
-
-          # Add indexes
-          create_indexes(t)
-        end
-      end
-
       def change_column(table, old_name, new_name, opts : Hash)
         ignore_foreign_keys do
           temp_table_name = "#{table}_temp"

--- a/src/sqlite3/schema_processor.cr
+++ b/src/sqlite3/schema_processor.cr
@@ -11,6 +11,29 @@ module Jennifer
         adapter.exec "DROP INDEX #{name}"
       end
 
+      def drop_column(table, name)
+        ignore_foreign_keys do
+          temp_table_name = "#{table}_temp"
+          t = find_table(table)
+          columns = t.columns.reject(&.name.==(name.to_s))
+
+          # Create new table
+          create_table(temp_table_name, columns, t.foreign_keys)
+
+          # Copy data
+          copy_data(temp_table_name, table, columns.map(&.name))
+
+          # Drop old table
+          drop_table(table)
+
+          # Rename new table
+          rename_table(temp_table_name, table)
+
+          # Add indexes
+          create_indexes(t)
+        end
+      end
+
       def change_column(table, old_name, new_name, opts : Hash)
         ignore_foreign_keys do
           temp_table_name = "#{table}_temp"


### PR DESCRIPTION
Fixes `Adapter#foreign_key_exists?` to accept both string and symbol for `to_table` and `column` arguments