### PR TITLE
Add all dynamic container types

### DIFF
--- a/.github/install_sqlite.sh
+++ b/.github/install_sqlite.sh
@@ -1,8 +1,14 @@
 set -exo pipefail
 
-sudo apt-get remove sqlite3
+if [-z "$SQLITE_VERSION"]; then
+  sudo apt-get remove sqlite3
 
-wget https://sqlite.org/2021/sqlite-tools-linux-x86-3360000.zip
-unzip sqlite-tools-linux-x86-3360000.zip
-sudo cp sqlite-tools-linux-x86-3360000/* /usr/bin
+  FOLDER_NAME="sqlite-tools-linux-x86-$SQLITE_VERSION"
+
+  wget "https://sqlite.org/$SQLITE_YEAR/$FOLDER_NAME.zip"
+  unzip "$FOLDER_NAME.zip"
+  sudo cp "$FOLDER_NAME/*" /usr/bin
+fi
+
+# 3.31.1 2020-01-27 by default
 sqlite3 --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,28 @@ jobs:
   test:
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - crystal_version: 1.0.0
+          - crystal_version: 1.1.0
+          - crystal_version: 1.2.2
+          - crystal_version: 1.3.2
+          - crystal_version: 1.4.1
+          - crystal_version: 1.4.1
+            sqlite_version: 3380300
+            sqlite_year: 2022
+          - crystal_version: 1.4.1
+            sqlite_version: 3370200
+            sqlite_year: 2022
+          - crystal_version: 1.4.1
+            sqlite_version: 3360000
+            sqlite_year: 2021
 
     runs-on: ubuntu-latest
+
+    env:
+      SQLITE_VERSION: ${{ matrix.sqlite_version }}
+      SQLITE_YEAR: ${{ matrix.sqlite_year }}
 
     steps:
       - name: Install Crystal

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dependencies:
 
 ## Usage
 
-This shard supports Jennifer `0.12.0` and above. It is tested with SQLite `3.36.0` version. Some of features may not work on older versions.
+This shard supports Jennifer `0.12.0` and above. It is tested with SQLite `3.31.1` version. Some of features may not work on older versions.
 
 ```crystal
 require "jennifer"

--- a/spec/jennifer_sqlite3_adapter_spec.cr
+++ b/spec/jennifer_sqlite3_adapter_spec.cr
@@ -194,7 +194,10 @@ describe Jennifer::SQLite3::Adapter do
     it "adds log message" do
       adapter.with_table_lock("any_table") { }
       Spec.logger_backend.entries[-2].severity.debug?.should be_true
-      Spec.logger_backend.entries[-2].message.should eq("SQLite3 doesn't support manual locking table from prepared statement. Instead of this only transaction was started.")
+      Spec.logger_backend.entries[-2].message.should eq(
+        "SQLite3 doesn't support manual locking table from prepared statement. " \
+        "Instead of this only transaction was started."
+      )
     end
   end
 
@@ -207,7 +210,7 @@ describe Jennifer::SQLite3::Adapter do
       result = adapter.explain(Jennifer::Query["users"].join("posts") { |origin, joined| joined._user_id == origin._id }).split("\n")
       result.size.should eq(3)
       result[0].should eq("selectid|order|from|detail")
-      result[1].should match(/\d\|\d\|\d\|SCAN posts/)
+      result[1].should match(/\d\|\d\|\d\|SCAN TABLE posts/)
     end
   end
 

--- a/spec/jennifer_sqlite3_adapter_spec.cr
+++ b/spec/jennifer_sqlite3_adapter_spec.cr
@@ -207,7 +207,7 @@ describe Jennifer::SQLite3::Adapter do
       result = adapter.explain(Jennifer::Query["users"].join("posts") { |origin, joined| joined._user_id == origin._id }).split("\n")
       result.size.should eq(3)
       result[0].should eq("selectid|order|from|detail")
-      result[1].should match(/\d\|\d\|\d\|SCAN TABLE posts/)
+      result[1].should match(/\d\|\d\|\d\|SCAN posts/)
     end
   end
 

--- a/spec/jennifer_sqlite3_adapter_spec.cr
+++ b/spec/jennifer_sqlite3_adapter_spec.cr
@@ -36,26 +36,62 @@ describe Jennifer::SQLite3::Adapter do
     context "with missing type" do
       it do
         expect_raises(Jennifer::BaseException) do
-          adapter.translate_type(:decimal)
+          adapter.translate_type(:xml)
         end
       end
     end
 
     describe "integer" do
       it do
-        %i(bool integer bigint short tinyint).each { |type| adapter.translate_type(type).should eq("integer") }
+        %i(integer bigint short tinyint).each { |type| adapter.translate_type(type).should eq("integer") }
       end
     end
 
-    describe "real" do
+    describe "boolean" do
       it do
-        %i(float double real).each { |type| adapter.translate_type(type).should eq("real") }
+        %i(bool).each { |type| adapter.translate_type(type).should eq("boolean") }
+      end
+    end
+
+    describe "float" do
+      it do
+        %i(float).each { |type| adapter.translate_type(type).should eq("float") }
+      end
+    end
+
+    describe "decimal" do
+      it do
+        %i(decimal).each { |type| adapter.translate_type(type).should eq("decimal") }
       end
     end
 
     describe "text" do
       it do
-        %i(text string varchar time timestamp).each { |type| adapter.translate_type(type).should eq("text") }
+        %i(text).each { |type| adapter.translate_type(type).should eq("text") }
+      end
+    end
+
+    describe "varchar" do
+      it do
+        %i(string varchar).each { |type| adapter.translate_type(type).should eq("varchar") }
+      end
+    end
+
+    describe "json" do
+      it do
+        %i(json).each { |type| adapter.translate_type(type).should eq("json") }
+      end
+    end
+
+    describe "date" do
+      it do
+        %i(date).each { |type| adapter.translate_type(type).should eq("date") }
+      end
+    end
+
+    describe "date_time" do
+      it do
+        %i(date_time timestamp).each { |type| adapter.translate_type(type).should eq("datetime") }
       end
     end
   end

--- a/spec/sqlite3/meta/column_spec.cr
+++ b/spec/sqlite3/meta/column_spec.cr
@@ -31,8 +31,8 @@ describe Jennifer::SQLite3::Column do
   end
 
   describe "#type" do
-    it { user_columns[1].type.should eq("text") }
-    it { user_columns[2].type.should eq("integer") }
+    it { user_columns[1].type.should eq("varchar") }
+    it { user_columns[2].type.should eq("INTEGER") }
   end
 
   describe "#name" do

--- a/spec/sqlite3/meta/column_spec.cr
+++ b/spec/sqlite3/meta/column_spec.cr
@@ -32,7 +32,7 @@ describe Jennifer::SQLite3::Column do
 
   describe "#type" do
     it { user_columns[1].type.should eq("varchar") }
-    it { user_columns[2].type.should eq("INTEGER") }
+    it { user_columns[2].type.should eq("integer") }
   end
 
   describe "#name" do

--- a/spec/sqlite3/schema_processor_spec.cr
+++ b/spec/sqlite3/schema_processor_spec.cr
@@ -71,7 +71,7 @@ describe Jennifer::SQLite3::SchemaProcessor do
           adapter.column_exists?("users", "age").should be_true
           User.all.count.should eq(2)
           adapter.index_exists?("users", "name_index").should be_true
-          master_class.table("users").first!.columns.find(&.name.==("age")).not_nil!.type.should eq("real")
+          master_class.table("users").first!.columns.find(&.name.==("age")).not_nil!.type.should eq("float")
         end
       end
     end

--- a/src/jennifer_sqlite3_adapter.cr
+++ b/src/jennifer_sqlite3_adapter.cr
@@ -16,23 +16,27 @@ module Jennifer
       alias EnumType = String
 
       TYPE_TRANSLATIONS = {
-        "bool" => "integer",
-
         "integer" => "integer",
         "bigint"  => "integer",
         "short"   => "integer",
         "tinyint" => "integer",
 
-        "float"  => "real",
-        "double" => "real",
-        "real"   => "real",
+        "float"  => "float",
+        "decimal"  => "decimal",
 
         "text"    => "text",
-        "string"  => "text",
-        "varchar" => "text",
+        "string"  => "varchar",
+        "varchar" => "varchar",
 
-        "time"      => "text",
-        "timestamp" => "text",
+        "blob" => "blob",
+        "boolean" => "boolean",
+        "bool" => "boolean",
+        "json" => "json",
+
+        "date" => "date",
+        "date_time" => "datetime",
+        "datetime" => "datetime",
+        "timestamp" => "datetime",
       }
 
       def self.default_max_bind_vars_count

--- a/src/jennifer_sqlite3_adapter.cr
+++ b/src/jennifer_sqlite3_adapter.cr
@@ -21,21 +21,21 @@ module Jennifer
         "short"   => "integer",
         "tinyint" => "integer",
 
-        "float"  => "float",
-        "decimal"  => "decimal",
+        "float"   => "float",
+        "decimal" => "decimal",
 
         "text"    => "text",
         "string"  => "varchar",
         "varchar" => "varchar",
 
-        "blob" => "blob",
+        "blob"    => "blob",
         "boolean" => "boolean",
-        "bool" => "boolean",
-        "json" => "json",
+        "bool"    => "boolean",
+        "json"    => "json",
 
-        "date" => "date",
+        "date"      => "date",
         "date_time" => "datetime",
-        "datetime" => "datetime",
+        "datetime"  => "datetime",
         "timestamp" => "datetime",
       }
 


### PR DESCRIPTION
While porting some of my Rails' app code I've noticed that the SQLite3 adapter defined a `time` type while the actual Jennifer code only supports [a `t.date_time` method](https://imdrasil.github.io/jennifer.cr/latest/Jennifer/Migration/TableBuilder/CreateTable.html#date_time(name:String%7CSymbol,options=DbOptions.new)-instance-method).  (Fixed in https://github.com/imdrasil/jennifer_sqlite3_adapter/pull/38)


Looking at the other `TYPE_TRANSLATIONS` it seems like the adapter is currently only mapping to the [underlying storage classes](https://www.sqlite.org/datatype3.html) and not SQLite's container types. This makes us miss out on many of the amazing SQLite3 query features around those types without explicitly casting.

This PR is mapping all types to their container types adapted from the Rails' SQLite3Adapter implementation: 
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb/#L64-L77

This might be a breaking change for existing schema, so it might require a major version bump.