### PR TITLE
Fix `time` type to match Jennifer implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 | `#text` | `TEXT` | `String` |
 | `#string` | `TEXT` | `String` |
 | `#varchar` | `TEXT` | `String` |
-| `#time` | `TEXT` | `Time` |
+| `#date_time` | `TEXT` | `Time` |
 | `#timestamp` | `TEXT` | `Time` |
 
 ### Altering table

--- a/spec/jennifer_sqlite3_adapter_spec.cr
+++ b/spec/jennifer_sqlite3_adapter_spec.cr
@@ -55,7 +55,7 @@ describe Jennifer::SQLite3::Adapter do
 
     describe "text" do
       it do
-        %i(text string varchar time timestamp).each { |type| adapter.translate_type(type).should eq("text") }
+        %i(text string varchar date_time timestamp).each { |type| adapter.translate_type(type).should eq("text") }
       end
     end
   end

--- a/src/jennifer_sqlite3_adapter.cr
+++ b/src/jennifer_sqlite3_adapter.cr
@@ -31,7 +31,7 @@ module Jennifer
         "string"  => "text",
         "varchar" => "text",
 
-        "time"      => "text",
+        "date_time" => "text",
         "timestamp" => "text",
       }
 


### PR DESCRIPTION
The `time` type is called `date_time` [in the newest version](https://github.com/imdrasil/jennifer.cr/blob/4b375baff918069103772937122dc2eed5fb428a/src/jennifer/adapter.cr#L19) of Jennifer.