### PR TITLE
Bump crystal-lang/crystal-sqlite3 version to 0.19

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ authors:
 development_dependencies:
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: "0.18.0"
+    version: "0.19.0"
   jennifer:
     github: imdrasil/jennifer.cr
     version: "0.12.0"


### PR DESCRIPTION
Update `crystal-sqlite3` to the newest version because it adds support for more `Time` string formats. (https://github.com/crystal-lang/crystal-sqlite3/pull/68)

