### PR TITLE
fix: Empty database won't be created

### DIFF
--- a/src/sqlite3/command_interface.cr
+++ b/src/sqlite3/command_interface.cr
@@ -4,7 +4,7 @@ module Jennifer
   module SQLite3
     class CommandInterface < Adapter::DBCommandInterface
       def create_database
-        options = [db_path, ""] of Command::Option
+        options = [db_path, "VACUUM;"] of Command::Option
         command = Command.new(
           executable: "sqlite3",
           options: options


### PR DESCRIPTION
## Summary
This Pull Request introduces an enhancement to the `SQLite3::CommandInterface` class within the `Adapter::DBCommandInterface` module. The modification aims to optimize the creation of SQLite databases by incorporating the `VACUUM` command during the database creation process.

## Testing
The changes have been tested to ensure that the `VACUUM` command executes correctly during the database creation process without introducing any errors.

## Feedback
Additional testing and feedback are encouraged to ensure the robustness and effectiveness of the changes across various use cases and environments.