### PR TITLE
fix: Database exists test won't success on Windows

### DIFF
--- a/src/sqlite3/command_interface.cr
+++ b/src/sqlite3/command_interface.cr
@@ -42,14 +42,7 @@ module Jennifer
       end
 
       def database_exists?
-        command = Command.new(
-          executable: "test",
-          options: ["-e", db_path] of Command::Option
-        )
-        execute(command)
-        true
-      rescue error : Command::Failed
-        false
+        File.exists?(db_path)
       end
 
       private def db_path


### PR DESCRIPTION
## Summary
The previous implementation of the `database_exists?` method used a command-line test command that is not compatible with Windows, causing the method to fail on Windows systems.

## Rationale
- **Cross-Platform Compatibility:**  The new implementation ensures that the method works correctly on Windows, enhancing the cross-platform compatibility of the codebase.
- **Performance Improvement**: The new implementation uses `File.exists?` to directly check for the existence of the database file. This is more efficient than executing an external command.
- **Code Simplification**: The updated code is simpler and easier to read, reducing the complexity and potential points of failure.

## Testing
- Ensure that the `database_exists?` method correctly identifies the existence of the database file on Windows.

## Additional Notes
- This change should not affect any dependent code that relies on the `database_exists?` method, as the method signature and return type remain unchanged.

Please review the changes and provide feedback.